### PR TITLE
Add button to compute required modules.

### DIFF
--- a/src/app/station/components/station-calculator.component.html
+++ b/src/app/station/components/station-calculator.component.html
@@ -6,7 +6,8 @@
         <button (click)="saveLayout()" class="btn btn-sm btn-primary" type="button"><i class="fa fa-save"></i>&nbsp;<span i18n="@@save">Save</span></button>&nbsp;
         <button (click)="saveLayoutAs()" class="btn btn-sm btn-primary" type="button"><i class="fa fa-save"></i>&nbsp;<span i18n="@@saveAs">Save As</span></button>&nbsp;
         <button (click)="loadLayout()" class="btn btn-sm btn-info" type="button"><i class="fa fa-folder-open"></i>&nbsp;<span i18n="@@load">Load</span></button>&nbsp;
-        <button (click)="shareLayout()" class="btn btn-sm btn-secondary" type="button"><i class="fa fa-share-square"></i>&nbsp;<span i18n="@@share">Share</span></button>
+        <button (click)="shareLayout()" class="btn btn-sm btn-secondary" type="button"><i class="fa fa-share-square"></i>&nbsp;<span i18n="@@share">Share</span></button>&nbsp;
+        <button (click)="backfillModules()" class="btn btn-sm btn-secondary" type="button"><i class="fa fa-battery"></i>&nbsp;<span i18n="@@backfillModules">Backfill Modules</span></button>
       </div>
       <div class="card-body">
         <div class="row" *ngIf="messages.length">

--- a/src/app/station/components/station-calculator.model.ts
+++ b/src/app/station/components/station-calculator.model.ts
@@ -40,8 +40,8 @@ export class StationModuleModel {
   module: StationModule;
   needs: { amount: number, ware: Ware }[];
   production: { amount: number, ware: Ware, value: Production };
-  count: number;
 
+  private _count: number;
   private _moduleId: string;
 
   constructor(private wareService: WareService, private moduleService: ModuleService, moduleId: string = '', count: number = 1) {
@@ -56,6 +56,17 @@ export class StationModuleModel {
   set moduleId(value: string) {
     if (value != this._moduleId) {
       this._moduleId = value;
+      this.update();
+    }
+  }
+
+  get count() {
+    return this._count;
+  }
+
+  set count(value: number) {
+    if (value != this._count) {
+      this._count = value;
       this.update();
     }
   }


### PR DESCRIPTION
Hi

I added the following functionality since I was looking for it but could not find it. Happy to make adjustments as requested :-)

When clicking the "Backfill Modules" button, the station calculator will add modules to provide for missing resources until only basic resources like Ore remain.

This is useful for planning/updating a self-sustained factory.